### PR TITLE
feat: add custom partizip to json object

### DIFF
--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   extends: [
     'airbnb-base',
-    'eslint:recommended',
+
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
   ],
@@ -14,7 +14,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 13,
     sourceType: 'module',
-    project: './tsconfig.json',
+    project: 'tsconfig.json',
     tsconfigRootDir: './',
   },
   plugins: ['@typescript-eslint', 'import'],
@@ -31,6 +31,7 @@ module.exports = {
       },
     ],
     'no-shadow': 'off',
+    'no-param-reassign': ['error', { props: false }],
     '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/no-misused-promises': [
       'error',

--- a/server/src/data/germanverbs.yaml
+++ b/server/src/data/germanverbs.yaml
@@ -46,7 +46,7 @@ werden:
       es: wurde
 
 können:
-  en: can, may, are able to, to know
+  en: can, may, are able to, to know how
   tags:
     - modal
   strong:

--- a/server/src/models/german/germanTypes.ts
+++ b/server/src/models/german/germanTypes.ts
@@ -17,6 +17,9 @@ export enum GermanTenses {
   k2präteritum = 'k2präteritum',
 }
 
+export type GermanIrregularSet = { GermanPronounKeys?: string };
+export type GermanIrregularObject = { [key in GermanTenses]?: GermanIrregularSet };
+
 export enum GermanStems {
   duEs = 'duEs',
   präteritum = 'präteritum',
@@ -29,17 +32,6 @@ export type GermanVerbHydrated = {
   [key in GermanTenses]?: { [person: string]: string };
 } & {
   partizip: string;
-};
-
-export type GermanVerb = {
-  drop: boolean;
-  hilfsverb: string;
-  infinitive: string;
-  irregular?: { GermanTenses?: [GermanPronounKeys: string] };
-  languages: LanguageMap;
-  stems?: { [key in GermanStems]?: string };
-  strong?: [string: boolean] | boolean;
-  weakEndings?: boolean;
 };
 
 export type GermanIrregular = {
@@ -83,4 +75,16 @@ export const GermanPronounKeys: { [key: string]: number } = {
     + GrammaticalNumber.Plural.valueOf()
     + GrammaticalFormal.Informal.valueOf()
     + GermanCase.Nominative.valueOf(),
+};
+
+export type GermanVerb = {
+  drop: boolean;
+  hilfsverb: string;
+  infinitive: string;
+  irregular?: GermanIrregularObject;
+  languages: LanguageMap;
+  partizip?: string;
+  stems?: { [key in GermanStems]?: string };
+  strong?: [string: boolean] | boolean;
+  weakEndings?: boolean;
 };

--- a/server/src/models/german/germanVerbs.spec.ts
+++ b/server/src/models/german/germanVerbs.spec.ts
@@ -1,7 +1,7 @@
 import { createVerb, DataObj } from './germanVerbs';
 
 describe('createVerb', () => {
-  it('populates fallen correctly', () => {
+  it('populates sein correctly', () => {
     const dataObj: DataObj = {
       en: 'to be',
       tags: ['hilfsverb'],
@@ -37,6 +37,7 @@ describe('createVerb', () => {
           1548: 'ist',
         },
       },
+      partizip: 'gewesen',
     };
     expect(result).toEqual(expected);
   });

--- a/server/src/models/german/testFunctions/verbIsIrregular.spec.ts
+++ b/server/src/models/german/testFunctions/verbIsIrregular.spec.ts
@@ -1,0 +1,35 @@
+import verbIsIrregular from './verbIsIrregular';
+import { DataObj } from '../germanVerbs';
+
+describe('verbIsIrregular correctly determines the state of the verb', () => {
+  it('flags fallen as not irregular', () => {
+    const fallenObj: DataObj = {
+      en: 'to fall',
+    };
+    const result = verbIsIrregular(fallenObj);
+    expect(result).not.toBeTruthy();
+  });
+
+  it('flags sein as irregular', () => {
+    const fallenObj: DataObj = {
+      en: 'to be',
+      tags: ['hilfsverb'],
+      hilfsverb: 'sein',
+      partizip: 'gewesen',
+      strong: true,
+      stems: { präteritum: 'war' },
+      irregular: {
+        präsens: {
+          ich: 'bin', du: 'bist', es: 'ist', wir: 'sind', ihr: 'seid',
+        },
+      },
+      'weak endings': false,
+    };
+
+    const result = verbIsIrregular(fallenObj);
+    expect(result).toBeTruthy();
+  });
+});
+
+// eslint-disable-next-line max-len
+// node node_modules/jest/bin/jest.js -i src/models/german/testFunctions/verbIsIrregular.spec.ts -t "verbIsIrregular correctly determines the state of the verb"

--- a/server/src/models/german/testFunctions/verbIsIrregular.ts
+++ b/server/src/models/german/testFunctions/verbIsIrregular.ts
@@ -1,0 +1,14 @@
+import { DataObj } from '../germanVerbs';
+
+export default function verbIsIrregular(dataObj: DataObj): boolean {
+  // no empty function
+  if (dataObj.strong
+    || dataObj['weak endings']
+    || dataObj.irregular
+    || dataObj.stems
+    || dataObj.partizip) {
+    return true;
+  }
+
+  return false;
+}

--- a/server/src/models/german/translateYtoJFunctions/createIrregularObject.spec.ts
+++ b/server/src/models/german/translateYtoJFunctions/createIrregularObject.spec.ts
@@ -1,0 +1,51 @@
+import createIrregularObject from './createIrregularObjet';
+import { DataObj } from '../germanVerbs';
+
+describe('createIrregularObject correctly modifies the object', () => {
+  it('does not modify sollen because it does not have irregular', () => {
+    const sollen: DataObj = {
+      en: 'to be expected to',
+      tags: ['modal'],
+      'drop ich/es präsens endings': true,
+    };
+    const result = createIrregularObject({ ...sollen });
+    expect(result).toEqual({});
+  });
+
+  it('does modify sein because it does have irregular', () => {
+    const sein: DataObj = {
+      en: 'to be',
+      tags: ['hilfsverb'],
+      hilfsverb: 'sein',
+      partizip: 'gewesen',
+      strong: true,
+      stems: { präteritum: 'war' },
+      irregular: {
+        präsens: {
+          ich: 'bin',
+          du: 'bist',
+          es: 'ist',
+          wir: 'sind',
+          ihr: 'seid',
+        },
+      },
+    };
+
+    const expected = {
+      präsens: {
+        1033: 'bin',
+        1041: 'sind',
+        1098: 'bist',
+        1106: 'seid',
+        1548: 'ist',
+      },
+    };
+
+    const result = createIrregularObject({ ...sein });
+
+    expect(result).toEqual(expected);
+  });
+});
+
+// eslint-disable-next-line max-len
+// node node_modules/jest/bin/jest.js -i src/models/german/translateYtoJFunctions/createIrregularObject.spec.ts -t "createIrregularObject correctly modifies the object"

--- a/server/src/models/german/translateYtoJFunctions/createIrregularObjet.ts
+++ b/server/src/models/german/translateYtoJFunctions/createIrregularObjet.ts
@@ -1,0 +1,30 @@
+import {
+  GermanIrregularObject, GermanIrregularSet, GermanPronounKeys, GermanTenses,
+} from '@german/germanTypes';
+import { DataObj } from '../germanVerbs';
+
+export default function createIrregularObject(dataObj: DataObj)
+  : GermanIrregularObject {
+  if (dataObj.irregular === undefined) {
+    return {};
+  }
+
+  const objectKeys = Object.keys(dataObj.irregular);
+  const irregularObj: GermanIrregularObject = {};
+
+  objectKeys.forEach((key: string) => {
+    const newKey: GermanTenses = GermanTenses[key] as GermanTenses;
+    const newDataObj = dataObj.irregular[key];
+
+    irregularObj[newKey] = <GermanIrregularSet>{};
+    const irregularRule: GermanTenses = irregularObj[newKey] as GermanTenses;
+    for (const pronounKey in newDataObj) {
+      if (Object.prototype.hasOwnProperty.call(newDataObj, pronounKey)) {
+        const pronoun: number = GermanPronounKeys[pronounKey];
+        irregularRule[pronoun.toString()] = newDataObj[pronounKey];
+      }
+    }
+  });
+
+  return irregularObj;
+}

--- a/server/src/models/german/translateYtoJFunctions/createIrregularVerbFeatures.spec.ts
+++ b/server/src/models/german/translateYtoJFunctions/createIrregularVerbFeatures.spec.ts
@@ -1,0 +1,122 @@
+import { GermanVerb, GermanTenses, GermanPronounKeys } from '@german/germanTypes';
+import { DataObj } from '../germanVerbs';
+
+import createIrregularVerbFeatures from './createIrregularVerbFeatures';
+
+describe('verbIsIrregular correctly determines the state of the verb', () => {
+  it('populates sein correctly', () => {
+    const newVerb: GermanVerb = {
+      drop: false,
+      hilfsverb: 'sein',
+      infinitive: 'sein',
+      languages: { en: 'to be' },
+    };
+
+    const seinObj: DataObj = {
+      en: 'to be',
+      tags: ['hilfsverb'],
+      hilfsverb: 'sein',
+      partizip: 'gewesen',
+      strong: true,
+      stems: { präteritum: 'war' },
+      irregular: {
+        präsens: {
+          ich: 'bin',
+          du: 'bist',
+          es: 'ist',
+          wir: 'sind',
+          ihr: 'seid',
+        },
+      },
+    };
+
+    const expected: GermanVerb = {
+      drop: false,
+      hilfsverb: 'sein',
+      infinitive: 'sein',
+      languages: { en: 'to be' },
+      partizip: 'gewesen',
+      strong: true,
+      stems: { präteritum: 'war' },
+      irregular: {
+        [GermanTenses.präsens]: {
+          [GermanPronounKeys.ich]: 'bin',
+          [GermanPronounKeys.du]: 'bist',
+          [GermanPronounKeys.es]: 'ist',
+          [GermanPronounKeys.wir]: 'sind',
+          [GermanPronounKeys.ihr]: 'seid',
+        },
+      }
+      ,
+    };
+
+    const result = createIrregularVerbFeatures({ newVerb, dataObj: seinObj });
+    expect(result).toEqual(expected);
+  });
+
+  it('populates können correctly', () => {
+    const english = 'can, may, are able to, to know how';
+
+    const newVerb: GermanVerb = {
+      drop: true,
+      hilfsverb: 'haben',
+      infinitive: 'können',
+      languages: { en: english },
+    };
+
+    const könnenObj: DataObj = {
+      en: english,
+      tags: ['modal'],
+      'weak endings': true,
+      strong: true,
+      stems: { 'präsens singular': 'a', präteritum: 'o' },
+      'drop ich/es präsens endings': true,
+    };
+
+    const expected: GermanVerb = {
+      drop: true,
+      hilfsverb: 'haben',
+      infinitive: 'können',
+      languages: { en: english },
+      strong: true,
+      stems: { präsensSingular: 'a', präteritum: 'o' },
+      weakEndings: true,
+    };
+
+    const result = createIrregularVerbFeatures({ newVerb, dataObj: könnenObj });
+    expect(result).toEqual(expected);
+  });
+
+
+  it('populates sollen correctly', () => {
+    const english = 'to be expected to';
+
+    const newVerb: GermanVerb = {
+      drop: true,
+      hilfsverb: 'haben',
+      infinitive: 'sollen',
+      languages: { en: english },
+    };
+
+    const sollenObj: DataObj = {
+      en: english,
+      tags: ['modal'],
+      strong: true,
+      'drop ich/es präsens endings': true,
+    };
+
+    const expected: GermanVerb = {
+      drop: true,
+      hilfsverb: 'haben',
+      infinitive: 'sollen',
+      languages: { en: english },
+      strong: true,
+    };
+
+    const result = createIrregularVerbFeatures({ newVerb, dataObj: sollenObj });
+    expect(result).toEqual(expected);
+  });
+});
+
+// eslint-disable-next-line max-len
+// node node_modules/jest/bin/jest.js -i src/models/german/translateYtoJFunctions/createIrregularVerbFeatures.spec.ts -t "verbIsIrregular correctly determines the state of the verb"

--- a/server/src/models/german/translateYtoJFunctions/createIrregularVerbFeatures.ts
+++ b/server/src/models/german/translateYtoJFunctions/createIrregularVerbFeatures.ts
@@ -1,0 +1,29 @@
+import { GermanVerb } from '@german/germanTypes';
+import { DataObj } from '../germanVerbs';
+import createIrregularObject from './createIrregularObjet';
+import createStems from './createStems';
+
+export default function createIrregularVerbFeatures(
+  { newVerb, dataObj }: { newVerb: GermanVerb, dataObj: DataObj },
+): GermanVerb {
+  const { partizip, irregular, stems } = dataObj;
+  newVerb.strong = true;
+
+  if (dataObj['weak endings']) {
+    newVerb.weakEndings = true;
+  }
+
+  if (partizip) {
+    newVerb.partizip = partizip;
+  }
+
+  if (irregular) {
+    newVerb.irregular = createIrregularObject(dataObj);
+  }
+
+  if (stems) {
+    newVerb.stems = createStems(dataObj);
+  }
+
+  return newVerb;
+}

--- a/server/src/models/german/translateYtoJFunctions/createStems.ts
+++ b/server/src/models/german/translateYtoJFunctions/createStems.ts
@@ -1,0 +1,22 @@
+import { GermanStems } from '@german/germanTypes';
+import { DataObj } from '../germanVerbs';
+
+const germanStemsDictionary = {
+  'präsens du/es': 'duEs',
+  präteritum: 'präteritum',
+  partizip: 'partizip',
+  'präsens singular': 'präsensSingular',
+  k2präsens: 'k2präsens',
+};
+
+export default function createStems(dataObj: DataObj) {
+  const objectKeys = Object.keys(dataObj.stems);
+  const stemsObj: { [key in GermanStems]?: string } = {};
+
+  objectKeys.forEach((key: string) => {
+    const enumKey: GermanStems = germanStemsDictionary[key] as GermanStems;
+    stemsObj[enumKey] = dataObj.stems[key];
+  });
+
+  return stemsObj;
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -12,7 +12,7 @@
     },
     "resolveJsonModule": true,
     "rootDir": "./src",
-    "sourceMap": false,
+    "sourceMap": true,
     "target": "es6"
   },
   "lib": ["es6"],


### PR DESCRIPTION
Added handling for the partizip top level object. 

- Fixed reference to TSConfig.
- Refactored and tested irregular processing.
- Allow updating properties of a parameter.
- Dropped complexity of the primary verb file by extracting some routines to their own files.